### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/mohan-the-octocat/ac2aca86-45b2-4221-b93b-1bd91a2fba6e/4a8be52d-22f2-4783-a913-f5edf1b63d58/_apis/work/boardbadge/b738cae5-36ed-4119-a1c5-6bcdcd496aa0)](https://dev.azure.com/mohan-the-octocat/ac2aca86-45b2-4221-b93b-1bd91a2fba6e/_boards/board/t/4a8be52d-22f2-4783-a913-f5edf1b63d58/Microsoft.RequirementCategory)
 # Getting Started with Create React App
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#6. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.